### PR TITLE
Make get_setting support None default

### DIFF
--- a/configstore/store.py
+++ b/configstore/store.py
@@ -43,7 +43,7 @@ class Store(object):
             return ret
 
         if default is not _no_default:
-            if "${" in default:
+            if isinstance(default, str) and "${" in default:
                 return self.interpolate(default)
             return default
         else:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -62,6 +62,12 @@ def test_store_interpolate():
     assert s == 'before staging after'
 
 
+def test_store_interpolate_none_default():
+    store = Store([])
+
+    assert store.get_setting('foo', None) is None
+
+
 def test_store_get_setting_interpolate_value():
     store = Store([DictBackend(
         environment='staging',


### PR DESCRIPTION
Interpolation make get_setting raise an exception when default is not a string. This PR makes it try to interpolate only when the default is a string.